### PR TITLE
Implement onboarding step 2

### DIFF
--- a/src/app/(private)/onboarding/page.tsx
+++ b/src/app/(private)/onboarding/page.tsx
@@ -1,87 +1,84 @@
-"use client";
+'use client';
 
-import { Button } from "@/components/ui/button";
-import { useFacebookSdk } from "@/hooks/use-facebook-sdk";
-import AuthService from "@/service/auth.service";
-import { useCallback, useState } from "react";
-const FB_SCOPES =
-  "public_profile,email,business_management,pages_show_list"; // ajuste se precisar
+import { Button } from '@/components/ui/button';
+import { OnboardingForm } from '@/components/business/onboarding/onboarding-form';
+import { useFacebookSdk } from '@/hooks/use-facebook-sdk';
+import AuthService from '@/service/auth.service';
+import { useCallback, useState } from 'react';
+import { useFacebookStore } from '@/store/facebook.store';
+import { useUserStore } from '@/store/report/user.store';
+const FB_SCOPES = 'public_profile,email,business_management,pages_show_list'; // ajuste se precisar
 
 export default function OnboardingPage() {
-  const sdkReady = useFacebookSdk(
-    process.env.NEXT_PUBLIC_FACEBOOK_APP_ID ?? ""
-  );
-   const authService = new AuthService();
+ const sdkReady = useFacebookSdk(process.env.NEXT_PUBLIC_FACEBOOK_APP_ID ?? '');
+ const authService = new AuthService();
+ const setFbToken = useFacebookStore((s) => s.setToken);
+ const setUser = useUserStore((s) => s.setUser);
 
-  const [status, setStatus] = useState<
-    "idle" | "loading" | "success" | "error"
-  >("idle");
-  const [errorMsg, setErrorMsg] = useState("");
+ const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>(
+  'idle'
+ );
+ const [errorMsg, setErrorMsg] = useState('');
 
-  const loginWithFacebook = useCallback(() => {
-    if (!sdkReady || !window.FB) return;
+ const loginWithFacebook = useCallback(() => {
+  if (!sdkReady || !window.FB) return;
 
-    setStatus("loading");
-    window.FB.login(
-      (response: fb.StatusResponse) => {
-        if (response.status === "connected") {
-          console.log(response);
-          const { code } = response.authResponse as { code: string };
-          exportCode(code);
-        } else {
-          setErrorMsg("Não foi possível conectar. Tente novamente.");
-          setStatus("error");
-        }
-      },
-      {
-        scope: FB_SCOPES,
-        // display: "popup", 
-        response_type: 'code',
-        config_id: '1051990639735066', 
-        // return_scopes: true,
-      }
-    );
-  }, [sdkReady]);
-
-  const exportCode = async (code: string) => {
-    try {
-      await authService.createTokenFacebook(code);
-      setStatus("success");
-    } catch (error) {
-      console.error("Erro atoken", error);
+  setStatus('loading');
+  window.FB.login(
+   (response: fb.StatusResponse) => {
+    if (response.status === 'connected') {
+     console.log(response);
+     const { code } = response.authResponse as { code: string };
+     exportCode(code);
+    } else {
+     setErrorMsg('Não foi possível conectar. Tente novamente.');
+     setStatus('error');
     }
-  }
-
-  return (
-    <div className="w-full lg:grid lg:min-h-[600px] xl:min-h-[800px]">
-      <div className="flex items-center justify-center py-12">
-        <div className="mx-auto grid w-[350px] gap-6">
-          <div className="grid gap-2 text-center">
-            <h1 className="text-2xl font-bold">
-              Conecte sua conta de anúncios Meta
-            </h1>
-            <p className="text-muted-foreground">
-              Conecte sua conta de anúncios para acessar seus criativos.
-            </p>
-
-            <Button
-              onClick={loginWithFacebook}
-              disabled={!sdkReady || status === "loading"}
-            >
-              {status === "loading" ? "Conectando..." : "Conectar com Facebook"}
-            </Button>
-
-            {status === "success" && (
-              <p className="text-sm text-green-600">
-                ✅ Usuário conectado com sucesso
-              </p>
-            )}
-            {status === "error" && (
-              <p className="text-sm text-red-600">⚠️ {errorMsg}</p>
-            )}
-          </div>
-        </div>
-      </div>
-    </div>
+   },
+   {
+    scope: FB_SCOPES,
+    // display: "popup",
+    response_type: 'code',
+    config_id: '1051990639735066',
+    // return_scopes: true,
+   }
   );
+ }, [sdkReady]);
+
+ const exportCode = async (code: string) => {
+  try {
+   const user = await authService.createTokenFacebook(code);
+   setFbToken(user.accessTokenFb);
+   setUser(user);
+   setStatus('success');
+  } catch (error) {
+   console.error('Erro atoken', error);
+  }
+ };
+
+ return (
+  <div className="w-full lg:grid lg:min-h-[600px] xl:min-h-[800px] p-6 flex justify-center">
+   {status !== 'success' ? (
+    <div className="mx-auto grid w-[350px] gap-6 self-start">
+     <div className="grid gap-2 text-center">
+      <h1 className="text-2xl font-bold">Conecte sua conta de anúncios Meta</h1>
+      <p className="text-muted-foreground">
+       Conecte sua conta de anúncios para acessar seus criativos.
+      </p>
+      <Button
+       onClick={loginWithFacebook}
+       disabled={!sdkReady || status === 'loading'}
+      >
+       {status === 'loading' ? 'Conectando...' : 'Conectar com Facebook'}
+      </Button>
+      {status === 'error' && (
+       <p className="text-sm text-red-600">⚠️ {errorMsg}</p>
+      )}
+     </div>
+    </div>
+   ) : (
+    <OnboardingForm />
+   )}
+  </div>
+ );
 }

--- a/src/app/(public)/login-facebook/page.tsx
+++ b/src/app/(public)/login-facebook/page.tsx
@@ -1,68 +1,66 @@
-"use client";
+'use client';
 
-import { useAuth } from "@/context/auth.context";
-import AuthService from "@/service/auth.service";
-import { Loader2 } from "lucide-react";
-import { useRouter, useSearchParams } from "next/navigation";
-import nookies from "nookies";
-import { Suspense, useEffect, useState } from "react";
+import { useAuth } from '@/context/auth.context';
+import AuthService from '@/service/auth.service';
+import { useFacebookStore } from '@/store/facebook.store';
+import { Loader2 } from 'lucide-react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import nookies from 'nookies';
+import { Suspense, useEffect, useState } from 'react';
 
 export default function DashboardPage() {
-  return (
-    <Suspense fallback={<div>Carregando...</div>}>
-      <Content />
-    </Suspense>
-  );
+ return (
+  <Suspense fallback={<div>Carregando...</div>}>
+   <Content />
+  </Suspense>
+ );
 }
 
 function Content() {
-  const authService = new AuthService();
-  const { findAdAccounts } = useAuth();
-  const [adAccounts, setAdAccounts] = useState<any>(null);
-  const [loading, setLoading] = useState<boolean>(true);
-  const searchParams = useSearchParams();
-  const code = searchParams.get("code");
-  const router = useRouter();
+ const authService = new AuthService();
+ const { findAdAccounts } = useAuth();
+ const setFbToken = useFacebookStore((s) => s.setToken);
+ const [loading, setLoading] = useState<boolean>(true);
+ const searchParams = useSearchParams();
+ const code = searchParams.get('code');
+ const router = useRouter();
 
-  useEffect(() => {
-    if (code) {
-      fetchAdAccounts(code);
-    }
-  }, [code]);
+ useEffect(() => {
+  if (code) {
+   fetchAdAccounts(code);
+  }
+ }, [code]);
 
-  const fetchAdAccounts = async (accessToken: string) => {
-    try {
-      await authService.createTokenFacebook(accessToken);
-    } catch (error) {
-      console.error("Erro atoken", error);
-    }
+ const fetchAdAccounts = async (accessToken: string) => {
+  try {
+   const profile = await authService.createTokenFacebook(accessToken);
+   setFbToken(profile.accessTokenFb);
+   nookies.set(null, 'user', JSON.stringify(profile), {
+    maxAge: 60 * 60 * 24 * 365 * 10,
+    path: '/',
+   });
+   setLoading(false);
+   await findAdAccounts();
+   router.push('/top-criativos-vendas');
+  } catch (error) {
+   console.error('Erro ao conectar:', error);
+  }
+ };
 
-    try {
-      const profile = await authService.getProfile();
-      nookies.set(null, "user", JSON.stringify(profile), {
-        maxAge: 60 * 60 * 24 * 365 * 10,
-        path: "/",
-      });
-      setLoading(false);
-      await findAdAccounts();
-      router.push("/top-criativos-vendas");
-    } catch (error) {
-      console.error("Erro ao buscar o profile:", error);
-    }
-  };
-
-  return (
-    <div className="w-full h-screen lg:grid">
-          <div className="flex h-full items-center justify-center py-12">
-            <div className="mx-auto grid w-full">
-              <div className="grid gap-8 text-center">
-                <h1 className="text-xl font-bold">{loading ? "Estamos conectando sua conta... aguarde." : "Redirecionando"}</h1>
-                <div className="flex">
-                  <Loader2 className="animate-spin mx-auto" />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-  );
+ return (
+  <div className="w-full h-screen lg:grid">
+   <div className="flex h-full items-center justify-center py-12">
+    <div className="mx-auto grid w-full">
+     <div className="grid gap-8 text-center">
+      <h1 className="text-xl font-bold">
+       {loading ? 'Estamos conectando sua conta... aguarde.' : 'Redirecionando'}
+      </h1>
+      <div className="flex">
+       <Loader2 className="animate-spin mx-auto" />
+      </div>
+     </div>
+    </div>
+   </div>
+  </div>
+ );
 }

--- a/src/components/business/onboarding/onboarding-form.tsx
+++ b/src/components/business/onboarding/onboarding-form.tsx
@@ -1,0 +1,135 @@
+'use client';
+import { Button } from '@/components/ui/button';
+import ErrorMessage from '@/components/ui/custom/error-message';
+import { Input } from '@/components/ui/input';
+import { onboardingSchema, OnboardingData } from '@/schemas/onboarding.schema';
+import FacebookAdsService from '@/service/graph-api.service';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { AdAccount } from '@/types/model/ad-account.model';
+
+export function OnboardingForm() {
+ const [accounts, setAccounts] = useState<AdAccount[]>([]);
+ const [connected, setConnected] = useState<AdAccount | null>(null);
+ const router = useRouter();
+
+ const {
+  register,
+  handleSubmit,
+  watch,
+  setValue,
+  formState: { errors },
+ } = useForm<OnboardingData>({
+  resolver: zodResolver(onboardingSchema),
+ });
+
+ const selectedId = watch('selectedAccountId');
+
+ useEffect(() => {
+  async function load() {
+   try {
+    const res = await FacebookAdsService.getAdAccounts();
+    setAccounts(res);
+   } catch (err) {
+    console.error(err);
+   }
+  }
+  load();
+ }, []);
+
+ const connect = () => {
+  const account = accounts.find((a) => a.id === selectedId);
+  if (!account) return;
+  setConnected(account);
+  setValue('workspaceName', account.name);
+ };
+
+ const onSubmit = (data: OnboardingData) => {
+  console.log(data);
+  router.push('/top-criativos-vendas');
+ };
+
+ return (
+  <form onSubmit={handleSubmit(onSubmit)} className="space-y-8">
+   <section className="space-y-2">
+    <h2 className="text-xl font-bold">Crie sua organização</h2>
+    <p className="text-sm text-muted-foreground">
+     A organização será a central do seu time
+    </p>
+    <Input
+     placeholder="Nome da organização"
+     {...register('organizationName')}
+    />
+    {errors.organizationName && (
+     <ErrorMessage message={errors.organizationName.message} />
+    )}
+   </section>
+
+   <section className="space-y-2">
+    <h2 className="text-xl font-bold">Conecte uma conta</h2>
+    <p className="text-sm text-muted-foreground">
+     Você terá acesso a essa conta no primeiro Workspace
+    </p>
+    <div className="overflow-auto rounded-md border">
+     <table className="w-full text-sm">
+      <thead>
+       <tr className="border-b bg-muted/50">
+        <th className="px-3 py-2 text-left font-medium">Account name</th>
+        <th className="px-3 py-2 text-left font-medium">Account id</th>
+        <th className="px-3 py-2" />
+       </tr>
+      </thead>
+      <tbody>
+       {accounts.map((acc) => (
+        <tr key={acc.id} className="border-b">
+         <td className="px-3 py-2">{acc.name}</td>
+         <td className="px-3 py-2">{acc.account_id}</td>
+         <td className="px-3 py-2 text-center">
+          <input
+           type="radio"
+           value={acc.id}
+           checked={selectedId === acc.id}
+           {...register('selectedAccountId')}
+           onChange={() => setValue('selectedAccountId', acc.id)}
+          />
+         </td>
+        </tr>
+       ))}
+      </tbody>
+     </table>
+    </div>
+    <Button
+     type="button"
+     onClick={connect}
+     disabled={!selectedId || !!connected}
+    >
+     Connect
+    </Button>
+    {errors.selectedAccountId && (
+     <ErrorMessage message={errors.selectedAccountId.message} />
+    )}
+   </section>
+
+   {connected && (
+    <section className="space-y-2">
+     <h2 className="text-xl font-bold">
+      Crie um workspace para {connected.name}
+     </h2>
+     <p className="text-sm text-muted-foreground">
+      Configure um espaço de trabalho que usará dados do {connected.name}
+     </p>
+     <Input placeholder="Nome do workspace" {...register('workspaceName')} />
+     {errors.workspaceName && (
+      <ErrorMessage message={errors.workspaceName.message} />
+     )}
+    </section>
+   )}
+
+   <Button type="submit" disabled={!connected}>
+    Finalizar
+   </Button>
+  </form>
+ );
+}

--- a/src/schemas/onboarding.schema.ts
+++ b/src/schemas/onboarding.schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const onboardingSchema = z.object({
+ organizationName: z.string().min(1, 'Nome da organização é obrigatório'),
+ selectedAccountId: z.string().min(1, 'Selecione uma conta'),
+ workspaceName: z.string().min(1, 'Nome do workspace é obrigatório'),
+});
+
+export type OnboardingData = z.infer<typeof onboardingSchema>;

--- a/src/service/graph-api.service.ts
+++ b/src/service/graph-api.service.ts
@@ -1,197 +1,205 @@
-import { AdAccount } from "@/types/model/ad-account.model";
-import { AdCreativeInsight, AdCreativeInsightsResponse } from "@/types/model/creative-insights.model";
-import { PaginatedResponseFacebook } from "@/types/paginated-response-facebook.interface";
-import axios from "axios";
-import nookies from "nookies";
+import { AdAccount } from '@/types/model/ad-account.model';
+import {
+ AdCreativeInsight,
+ AdCreativeInsightsResponse,
+} from '@/types/model/creative-insights.model';
+import { PaginatedResponseFacebook } from '@/types/paginated-response-facebook.interface';
+import axios from 'axios';
+import { useFacebookStore } from '@/store/facebook.store';
 
-const FACEBOOK_API_URL = "https://graph.facebook.com/v22.0";
+const FACEBOOK_API_URL = 'https://graph.facebook.com/v22.0';
 
-// Função auxiliar para extrair o token do Facebook do cookie "user"
+// Recupera o token do Facebook armazenado em zustand
 function getFacebookToken(): string {
-  const cookies = nookies.get(null);
-  if (cookies.user) {
-    try {
-      const user = JSON.parse(cookies.user);
-      if (user.accessTokenFb) {
-        return user.accessTokenFb;
-      }
-    } catch (err) {
-      console.error("Erro ao parsear o cookie 'user':", err);
-    }
-  }
-  throw new Error("Token do Facebook não disponível");
+ const token = useFacebookStore.getState().token;
+ if (token) {
+  return token;
+ }
+ throw new Error('Token do Facebook não disponível');
 }
 
 const FacebookAdsService = {
-  async getAdAccounts(): Promise<AdAccount[]> {
-    const tokenFb = getFacebookToken();
-    const response = await axios.get(`${FACEBOOK_API_URL}/me/adaccounts?limit=300`, {
-      params: {
-        fields:
-          "id,account_id,name,account_status,currency,amount_spent,balance,timezone_name,business",
-        access_token: tokenFb,
-      },
-    });
-    return response.data.data;
-  },
+ async getAdAccounts(): Promise<AdAccount[]> {
+  const tokenFb = getFacebookToken();
+  const response = await axios.get(
+   `${FACEBOOK_API_URL}/me/adaccounts?limit=300`,
+   {
+    params: {
+     fields:
+      'id,account_id,name,account_status,currency,amount_spent,balance,timezone_name,business',
+     access_token: tokenFb,
+    },
+   }
+  );
+  return response.data.data;
+ },
 
-  async getAdInsights(
-    adAccountId: string,
-    since: string,
-    until: string
-  ): Promise<PaginatedResponseFacebook<AdCreativeInsight>> {
-    const tokenFb = getFacebookToken();
-    const timeRange = { since, until };
-    const response = await axios.get<PaginatedResponseFacebook<AdCreativeInsight>>(
-      `${FACEBOOK_API_URL}/${adAccountId}/insights`,
-      {
-        params: {
-          level: "ad",
-          fields: "ad_name,ad_id,impressions,clicks,spend,date_start,date_stop",
-          time_range: JSON.stringify(timeRange),
-          limit: 150,
-          access_token: tokenFb,
-        },
-      }
-    );
-    return response.data;
-  },
+ async getAdInsights(
+  adAccountId: string,
+  since: string,
+  until: string
+ ): Promise<PaginatedResponseFacebook<AdCreativeInsight>> {
+  const tokenFb = getFacebookToken();
+  const timeRange = { since, until };
+  const response = await axios.get<
+   PaginatedResponseFacebook<AdCreativeInsight>
+  >(`${FACEBOOK_API_URL}/${adAccountId}/insights`, {
+   params: {
+    level: 'ad',
+    fields: 'ad_name,ad_id,impressions,clicks,spend,date_start,date_stop',
+    time_range: JSON.stringify(timeRange),
+    limit: 150,
+    access_token: tokenFb,
+   },
+  });
+  return response.data;
+ },
 
-   /**
-   * Retorna metadados de um vídeo específico
-   * @param videoId string
-   * @param accessToken string
-   */
-  async getVideoCreative(videoId: string) {
-    const tokenFb = getFacebookToken();
-    // Aqui você pode adaptar para sua versão / requirements de permissões
-    const fields = "source,thumbnails";
-    const response = await axios.get(`${FACEBOOK_API_URL}/${videoId}`, {
-      params: {
-        fields,
-        access_token: tokenFb,
-      },
-    });
-    return response.data; // Ex.: { id: "...", source: "https://..." }
-  },
+ /**
+  * Retorna metadados de um vídeo específico
+  * @param videoId string
+  * @param accessToken string
+  */
+ async getVideoCreative(videoId: string) {
+  const tokenFb = getFacebookToken();
+  // Aqui você pode adaptar para sua versão / requirements de permissões
+  const fields = 'source,thumbnails';
+  const response = await axios.get(`${FACEBOOK_API_URL}/${videoId}`, {
+   params: {
+    fields,
+    access_token: tokenFb,
+   },
+  });
+  return response.data; // Ex.: { id: "...", source: "https://..." }
+ },
 
-  async getCampaigns(adAccountId: string) {
-    const tokenFb = getFacebookToken();
-    const response = await axios.get(`${FACEBOOK_API_URL}/${adAccountId}/campaigns`, {
-      params: {
-        fields: "id,name,status,objective,start_time,stop_time,daily_budget",
-        access_token: tokenFb,
-      },
-    });
-    return response.data.data;
-  },
+ async getCampaigns(adAccountId: string) {
+  const tokenFb = getFacebookToken();
+  const response = await axios.get(
+   `${FACEBOOK_API_URL}/${adAccountId}/campaigns`,
+   {
+    params: {
+     fields: 'id,name,status,objective,start_time,stop_time,daily_budget',
+     access_token: tokenFb,
+    },
+   }
+  );
+  return response.data.data;
+ },
 
-  async getAllActiveAds(adAccountId: string): Promise<PaginatedResponseFacebook<AdCreativeInsight>> {
-    const tokenFb = getFacebookToken();
-    const response = await axios.get<PaginatedResponseFacebook<AdCreativeInsight>>(
-      `${FACEBOOK_API_URL}/${adAccountId}/ads`,
-      {
-        params: {
-          fields:
-            'id,name,creative{id,name,object_story_spec},insights.time_range({"since":"2024-01-01","until":"2024-03-02"}){spend,impressions,clicks,ctr,date_start,date_stop,actions,purchase_roas}',
-          effective_status: '["ACTIVE"]',
-          limit: 200,
-          access_token: tokenFb,
-        },
-      }
-    );
-    return response.data;
-  },
+ async getAllActiveAds(
+  adAccountId: string
+ ): Promise<PaginatedResponseFacebook<AdCreativeInsight>> {
+  const tokenFb = getFacebookToken();
+  const response = await axios.get<
+   PaginatedResponseFacebook<AdCreativeInsight>
+  >(`${FACEBOOK_API_URL}/${adAccountId}/ads`, {
+   params: {
+    fields:
+     'id,name,creative{id,name,object_story_spec},insights.time_range({"since":"2024-01-01","until":"2024-03-02"}){spend,impressions,clicks,ctr,date_start,date_stop,actions,purchase_roas}',
+    effective_status: '["ACTIVE"]',
+    limit: 200,
+    access_token: tokenFb,
+   },
+  });
+  return response.data;
+ },
 
-  async getFilteredAds(
-    adAccountId: string,
-    adIds: string[],
-    since: string,
-    until: string
-  ): Promise<PaginatedResponseFacebook<AdCreativeInsight>> {
-    const tokenFb = getFacebookToken();
-    const filtering = [
-      {
-        field: "ad.id",
-        operator: "IN",
-        value: adIds,
-      },
-    ];
-    const timeRange = { since, until };
-    const fields = [
-      "id",
-      "name",
-      "effective_status",
-      "creative{id,name,object_story_spec,image_url,thumbnail_url}",
-      `insights.time_range(${JSON.stringify(timeRange)}){spend,impressions,clicks,ctr,date_start,date_stop,actions,purchase_roas}`
-    ].join(",");
-    const response = await axios.get<PaginatedResponseFacebook<AdCreativeInsight>>(
-      `${FACEBOOK_API_URL}/${adAccountId}/ads`,
-      {
-        params: {
-          fields,
-          filtering: JSON.stringify(filtering),
-          limit: 1000,
-          access_token: tokenFb,
-        },
-      }
-    );
-    return response.data;
-  },
+ async getFilteredAds(
+  adAccountId: string,
+  adIds: string[],
+  since: string,
+  until: string
+ ): Promise<PaginatedResponseFacebook<AdCreativeInsight>> {
+  const tokenFb = getFacebookToken();
+  const filtering = [
+   {
+    field: 'ad.id',
+    operator: 'IN',
+    value: adIds,
+   },
+  ];
+  const timeRange = { since, until };
+  const fields = [
+   'id',
+   'name',
+   'effective_status',
+   'creative{id,name,object_story_spec,image_url,thumbnail_url}',
+   `insights.time_range(${JSON.stringify(timeRange)}){spend,impressions,clicks,ctr,date_start,date_stop,actions,purchase_roas}`,
+  ].join(',');
+  const response = await axios.get<
+   PaginatedResponseFacebook<AdCreativeInsight>
+  >(`${FACEBOOK_API_URL}/${adAccountId}/ads`, {
+   params: {
+    fields,
+    filtering: JSON.stringify(filtering),
+    limit: 1000,
+    access_token: tokenFb,
+   },
+  });
+  return response.data;
+ },
 
-  async testeAds(adAccountId: string): Promise<any> {
-    const tokenFb = getFacebookToken();
-    const url = `${FACEBOOK_API_URL}/${adAccountId}/ads?` +
-      `fields=id,name,created_time,updated_time,effective_status&` +
-      `filtering=[{"field":"ad.created_time","operator":"GREATER_THAN","value":"2025-01-01"},{"field":"ad.created_time","operator":"LESS_THAN","value":"2025-01-31"}]&` +
-      `access_token=${tokenFb}`;
-    const response = await axios.get<any>(url);
-    return response.data;
-  },
+ async testeAds(adAccountId: string): Promise<any> {
+  const tokenFb = getFacebookToken();
+  const url =
+   `${FACEBOOK_API_URL}/${adAccountId}/ads?` +
+   `fields=id,name,created_time,updated_time,effective_status&` +
+   `filtering=[{"field":"ad.created_time","operator":"GREATER_THAN","value":"2025-01-01"},{"field":"ad.created_time","operator":"LESS_THAN","value":"2025-01-31"}]&` +
+   `access_token=${tokenFb}`;
+  const response = await axios.get<any>(url);
+  return response.data;
+ },
 
-  async getAdSets(campaignId: string) {
-    const tokenFb = getFacebookToken();
-    const response = await axios.get(`${FACEBOOK_API_URL}/${campaignId}/adsets`, {
-      params: {
-        fields: "id,name,status,daily_budget,start_time,end_time",
-        access_token: tokenFb,
-      },
-    });
-    return response.data.data;
-  },
+ async getAdSets(campaignId: string) {
+  const tokenFb = getFacebookToken();
+  const response = await axios.get(`${FACEBOOK_API_URL}/${campaignId}/adsets`, {
+   params: {
+    fields: 'id,name,status,daily_budget,start_time,end_time',
+    access_token: tokenFb,
+   },
+  });
+  return response.data.data;
+ },
 
-  async getAds(adSetId: string) {
-    const tokenFb = getFacebookToken();
-    const response = await axios.get(`${FACEBOOK_API_URL}/${adSetId}/ads`, {
-      params: {
-        fields: "id,name,status,creative{thumbnail_url,image_url,video_id}",
-        access_token: tokenFb,
-      },
-    });
-    return response.data.data;
-  },
+ async getAds(adSetId: string) {
+  const tokenFb = getFacebookToken();
+  const response = await axios.get(`${FACEBOOK_API_URL}/${adSetId}/ads`, {
+   params: {
+    fields: 'id,name,status,creative{thumbnail_url,image_url,video_id}',
+    access_token: tokenFb,
+   },
+  });
+  return response.data.data;
+ },
 
-  async getCreative(creativeId: string) {
-    const tokenFb = getFacebookToken();
-    const response = await axios.get(`${FACEBOOK_API_URL}/${creativeId}`, {
-      params: {
-        fields: "id,name,thumbnail_url,image_url,video_id",
-        access_token: tokenFb,
-      },
-    });
-    return response.data;
-  },
-  
-  async getCreativeInsights(adAccountId: string): Promise<AdCreativeInsightsResponse> {
-    const tokenFb = getFacebookToken();
-    const response = await axios.get<AdCreativeInsightsResponse>(`${FACEBOOK_API_URL}/${adAccountId}/ads`, {
-      params: {
-        fields: "id,name,creative{id},insights{spend,impressions,clicks,ctr,date_start,date_stop}",
-        access_token: tokenFb,
-      },
-    });
-    return response.data;
-  }
+ async getCreative(creativeId: string) {
+  const tokenFb = getFacebookToken();
+  const response = await axios.get(`${FACEBOOK_API_URL}/${creativeId}`, {
+   params: {
+    fields: 'id,name,thumbnail_url,image_url,video_id',
+    access_token: tokenFb,
+   },
+  });
+  return response.data;
+ },
+
+ async getCreativeInsights(
+  adAccountId: string
+ ): Promise<AdCreativeInsightsResponse> {
+  const tokenFb = getFacebookToken();
+  const response = await axios.get<AdCreativeInsightsResponse>(
+   `${FACEBOOK_API_URL}/${adAccountId}/ads`,
+   {
+    params: {
+     fields:
+      'id,name,creative{id},insights{spend,impressions,clicks,ctr,date_start,date_stop}',
+     access_token: tokenFb,
+    },
+   }
+  );
+  return response.data;
+ },
 };
 
 export default FacebookAdsService;

--- a/src/store/facebook.store.ts
+++ b/src/store/facebook.store.ts
@@ -1,0 +1,22 @@
+'use client';
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface FacebookState {
+ token: string | null;
+ setToken: (token: string | null) => void;
+ clear: () => void;
+}
+
+export const useFacebookStore = create<FacebookState>()(
+ persist(
+  (set) => ({
+   token: null,
+   setToken: (token) => set({ token }),
+   clear: () => set({ token: null }),
+  }),
+  {
+   name: 'facebook-token',
+  }
+ )
+);


### PR DESCRIPTION
## Summary
- add zustand store to keep facebook token
- load facebook token from store in graph-api service
- persist facebook token when logging in with Facebook
- build onboarding form with organization, account and workspace steps
- integrate onboarding page with new form

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68434fbe32b48326978cbd4d97dbcf9a